### PR TITLE
Hotfix/2.0.1

### DIFF
--- a/src/senet/Board.java
+++ b/src/senet/Board.java
@@ -160,6 +160,7 @@ public class Board {
 				if (squares[i] == null) {
 					squares[i] = player;
 					squares[location] = null;
+					break;
 				}
 				i += 1;
 			}

--- a/src/senet/Board.java
+++ b/src/senet/Board.java
@@ -157,6 +157,9 @@ public class Board {
 			System.out.println("\nTrapdoor! Sending this pawn back to the beginning...");
 			int i = 0;
 			while (true) {
+				if (i == squares.length) {
+					return false;
+				}
 				if (squares[i] == null) {
 					squares[i] = player;
 					squares[location] = null;


### PR DESCRIPTION
# Hotfix/2.0.1
This patch fixes an issue where the game would crash when attempting to move a pawn to square 27. An infinite loop attempting to access an array caused an `ArrayIndexOutOfBoundsException`